### PR TITLE
vercel deployment fix #02 - increased the maximum chunk file size

### DIFF
--- a/stackclique/src/components/FaqComponent/Faq.jsx
+++ b/stackclique/src/components/FaqComponent/Faq.jsx
@@ -94,6 +94,7 @@ const Faq = () => {
     );
 
     return (
+        <>
         <div className="xl:w-[60%] md:w-[80%] w-full mt-8 p-4 mx-auto">
             <div className="md:flex  gap-20 md:my-20 my-8">
                 <div>
@@ -148,6 +149,7 @@ const Faq = () => {
                 </p>
             )}
         </div>
+        </>
     );
 };
 

--- a/stackclique/src/components/FaqComponent/Faq.jsx
+++ b/stackclique/src/components/FaqComponent/Faq.jsx
@@ -135,8 +135,8 @@ const Faq = () => {
                 filteredAccordionItems.map((item, index) => (
                     <>
                         <AccordionItem
-                            className="grid grid-cols-2"
                             key={index}
+                            className="grid grid-cols-2"
                             title={item.title}
                             content={item.content}
                         />

--- a/stackclique/src/pages/AboutUs.jsx
+++ b/stackclique/src/pages/AboutUs.jsx
@@ -1,5 +1,4 @@
 import { Button } from "../components/ui";
-
 import AboutUsImg1 from "../assets/pics/about-us-1.webp";
 import AboutUsImg2 from "../assets/pics/about-us-2.webp";
 import AboutUsImg3 from "../assets/pics/about-us-3.webp";

--- a/stackclique/src/pages/AboutUs.jsx
+++ b/stackclique/src/pages/AboutUs.jsx
@@ -3,7 +3,7 @@ import AboutUsImg1 from "../assets/pics/about-us-1.webp";
 import AboutUsImg2 from "../assets/pics/about-us-2.webp";
 import AboutUsImg3 from "../assets/pics/about-us-3.webp";
 import MergeGit from "../assets/svg/merge-git.svg";
-import Idea from "../assets/svg/idea.svg";
+import { ReactComponent as Idea } from "../assets/svg/idea.svg";
 import PersonalGrowth from "../assets/svg/personal-growth.svg";
 import Faq from "../components/FaqComponent/Faq";
 

--- a/stackclique/vite.config.js
+++ b/stackclique/vite.config.js
@@ -3,5 +3,20 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+    plugins: [react()],
+    build: {
+        rollupOptions: {
+            output: {
+                manualChunks(id) {
+                    if (id.includes("node_modules")) {
+                        return id
+                            .toString()
+                            .split("node_modules/")[1]
+                            .split("/")[0]
+                            .toString();
+                    }
+                },
+            },
+        },
+    },
+});

--- a/stackclique/vite.config.js
+++ b/stackclique/vite.config.js
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -18,5 +18,8 @@ export default defineConfig({
                 },
             },
         },
+    },
+    paths: {
+        "*": ["*", "*.tsx"],
     },
 });


### PR DESCRIPTION
The Vercel server was having issues with processing the image files due to the default 500KB max chunk file policy. Overwritten the command and now we should be about to get larger files in there.